### PR TITLE
Base consequence

### DIFF
--- a/Assets/Scripts/Consequences/AbstractConsequence.cs
+++ b/Assets/Scripts/Consequences/AbstractConsequence.cs
@@ -1,0 +1,11 @@
+#nullable enable
+using Triggers;
+using UnityEngine;
+
+namespace Consequences
+{
+    public abstract class AbstractConsequence : MonoBehaviour, IConsequence
+    {
+        public abstract void execute(TriggerData? data);
+    }
+}

--- a/Assets/Scripts/Consequences/AbstractConsequence.cs.meta
+++ b/Assets/Scripts/Consequences/AbstractConsequence.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 48ae0978b72f36748bb57061e3db9b85
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Consequences/AutomaticFireConsequence.cs
+++ b/Assets/Scripts/Consequences/AutomaticFireConsequence.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace Consequences
 {
-    public class AutomaticFireConsequence : MonoBehaviour, IConsequence
+    public class AutomaticFireConsequence : AbstractConsequence
     {
         public float secondsToFire = 1f;
     
@@ -65,7 +65,7 @@ namespace Consequences
             return this._lastExecutedTime + this.secondsToFire > Time.time;
         }
 
-        public void execute(TriggerData? data)
+        public override void execute(TriggerData? data)
         {
             this._lastExecutedTime = Time.time;
         }

--- a/Assets/Scripts/Consequences/CureStatusEffectConsequence.cs
+++ b/Assets/Scripts/Consequences/CureStatusEffectConsequence.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace Consequences
 {
-    public class CureStatusEffectConsequence : MonoBehaviour, IConsequence
+    public class CureStatusEffectConsequence : AbstractConsequence
     {
         public string statusEffectName = "burning";
         private PlayerHealthState _playerHealthStatus;
@@ -14,7 +14,7 @@ namespace Consequences
             this._playerHealthStatus = FindObjectOfType<PlayerHealthState>();
         }
 
-        public void execute(TriggerData? data)
+        public override void execute(TriggerData? data)
         {
             _playerHealthStatus.Cure(statusEffectName);
         }

--- a/Assets/Scripts/Consequences/CycleMultipleConsequencesConsequence.cs
+++ b/Assets/Scripts/Consequences/CycleMultipleConsequencesConsequence.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace Consequences
 {
-    public class CycleMultipleConsequencesConsequence : MonoBehaviour, IConsequence
+    public class CycleMultipleConsequencesConsequence : AbstractConsequence
     {
         public GameObject[] toCycleBetween;
         protected int currentIndex = -1;
@@ -17,7 +17,7 @@ namespace Consequences
             }
         }
 
-        public void execute(TriggerData? data)
+        public override void execute(TriggerData? data)
         {
             this.currentIndex = (this.currentIndex + 1) % toCycleBetween.Length;
             foreach (IConsequence consequence in toCycleBetween[currentIndex].GetComponents<IConsequence>())

--- a/Assets/Scripts/Consequences/DeathConsequence.cs
+++ b/Assets/Scripts/Consequences/DeathConsequence.cs
@@ -4,11 +4,11 @@ using UnityEngine;
 
 namespace Consequences
 {
-    public class DeathConsequence : MonoBehaviour, IConsequence
+    public class DeathConsequence : AbstractConsequence
     {
         public string deathReason;
 
-        public void execute(TriggerData? data)
+        public override void execute(TriggerData? data)
         {
             GameManager.instance.CommitDie(deathReason);
         }

--- a/Assets/Scripts/Consequences/ExecuteAfterTimeElapsedConsequence.cs
+++ b/Assets/Scripts/Consequences/ExecuteAfterTimeElapsedConsequence.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace Consequences
 {
-    public class ExecuteAfterTimeElapsedConsequence : MonoBehaviour, IConsequence
+    public class ExecuteAfterTimeElapsedConsequence : AbstractConsequence
     {
         public float waitTimeSeconds = 2f;
         public bool includeChildren = false;
@@ -40,7 +40,7 @@ namespace Consequences
             }
         }
 
-        public void execute(TriggerData? data)
+        public override void execute(TriggerData? data)
         {
             this.startTime = Time.time;
             this.triggerDataFromActivator = data;

--- a/Assets/Scripts/Consequences/ExecuteMultipleConsequencesConsequence.cs
+++ b/Assets/Scripts/Consequences/ExecuteMultipleConsequencesConsequence.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace Consequences
 {
-    public class ExecuteMultipleConsequencesConsequence : MonoBehaviour, IConsequence
+    public class ExecuteMultipleConsequencesConsequence : AbstractConsequence
     {
         [SerializeField]
         protected GameObject[] objectsWithConsequences;
@@ -14,7 +14,7 @@ namespace Consequences
         [SerializeField] 
         protected bool executeInChildren = false;
         
-        public void execute(TriggerData? data)
+        public override void execute(TriggerData? data)
         {
             foreach (var consequenceObject in objectsWithConsequences)
             {

--- a/Assets/Scripts/Consequences/InflictStatusEffectConsequence.cs
+++ b/Assets/Scripts/Consequences/InflictStatusEffectConsequence.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace Consequences
 {
-    public class InflictStatusEffectConsequence : MonoBehaviour, IConsequence
+    public class InflictStatusEffectConsequence : AbstractConsequence
     {
         public string statusEffectName = "burning";
         private PlayerHealthState _playerHealthStatus;
@@ -14,7 +14,7 @@ namespace Consequences
             this._playerHealthStatus = FindObjectOfType<PlayerHealthState>();
         }
 
-        public void execute(TriggerData? data)
+        public override void execute(TriggerData? data)
         {
             _playerHealthStatus.Hurt(statusEffectName, Time.deltaTime);
         }

--- a/Assets/Scripts/Consequences/MoveObjectAlongWaypointsConsequence.cs
+++ b/Assets/Scripts/Consequences/MoveObjectAlongWaypointsConsequence.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace Consequences
 {
-    public class MoveObjectAlongWaypointsConsequence : MonoBehaviour, IConsequence
+    public class MoveObjectAlongWaypointsConsequence : AbstractConsequence
     {
         public GameObject toMove;
         public bool loop = false;
@@ -90,7 +90,7 @@ namespace Consequences
             return this._currentWaypointIndex >= this.waypoints.Length;
         }
 
-        public virtual void execute(TriggerData? data)
+        public override void execute(TriggerData? data)
         {
             this._active = true;
         }

--- a/Assets/Scripts/Consequences/MoveObjectInSquareConsequence.cs
+++ b/Assets/Scripts/Consequences/MoveObjectInSquareConsequence.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace Consequences
 {
-    public class MoveObjectInSquareConsequence : MonoBehaviour, IConsequence
+    public class MoveObjectInSquareConsequence : AbstractConsequence
     {
         public GameObject toMove;
         public bool loop = false;
@@ -24,7 +24,7 @@ namespace Consequences
             return waypointsInRectangle;
         }
 
-        public void execute(TriggerData? data)
+        public override void execute(TriggerData? data)
         {
             MoveObjectAlongWaypoints moveAlongWaypoints = toMove.AddComponent<MoveObjectAlongWaypoints>();
             moveAlongWaypoints.loop = loop;

--- a/Assets/Scripts/Consequences/MovePlayerConsequence.cs
+++ b/Assets/Scripts/Consequences/MovePlayerConsequence.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace Consequences
 {
-    public class MovePlayerConsequence : MonoBehaviour, IConsequence
+    public class MovePlayerConsequence : AbstractConsequence
     {
         public Vector3 relativeDestination;
         protected KinematicCharacterMotor motor;
@@ -15,7 +15,7 @@ namespace Consequences
             this.motor = FindObjectOfType<KinematicCharacterMotor>();
         }
 
-        public void execute(TriggerData? data)
+        public override void execute(TriggerData? data)
         {
             this.motor.SetPosition(this.motor.TransientPosition + relativeDestination);
         }

--- a/Assets/Scripts/Consequences/PlayParticleSystemAtLocationConsequence.cs
+++ b/Assets/Scripts/Consequences/PlayParticleSystemAtLocationConsequence.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace Consequences
 {
-    public class PlayParticleSystemAtLocationConsequence : MonoBehaviour, IConsequence
+    public class PlayParticleSystemAtLocationConsequence : AbstractConsequence
     {
         public ParticleSystem toPlay;
 
@@ -17,7 +17,7 @@ namespace Consequences
             }
         }
 
-        public void execute(TriggerData? data)
+        public override void execute(TriggerData? data)
         {
 
             Vector3 positionToSplatAt = this.gameObject.transform.position; 

--- a/Assets/Scripts/Consequences/RotateConsequence.cs
+++ b/Assets/Scripts/Consequences/RotateConsequence.cs
@@ -1,22 +1,46 @@
 #nullable enable
 using Triggers;
+using UnityEngine;
 
 namespace Consequences
 {
-    public class RotateConsequence : DoASpinny, IConsequence
+    public class RotateConsequence : MonoBehaviour, IConsequence
     {
 
-        private float _speed;
+        public float speed;
+        public float max = float.PositiveInfinity;
+
+        protected float rotato = 0;
+        protected bool active = false;
 
         void Start()
         {
-            _speed = speed;
-            speed = 0;
+            if (max <= 0)
+            {
+                max = float.PositiveInfinity;
+            }
+            if(speed == 0){
+                speed = 1;
+            }
+        }
+        
+        void FixedUpdate()
+        {
+            if (active)
+            {
+                rotato += speed;
+                if (Mathf.Abs(rotato) >= Mathf.Abs(max))
+                {
+                    rotato = max;
+                }
+
+                transform.localRotation = Quaternion.Euler(0, rotato, 0);
+            }
         }
 
         public void execute(TriggerData? data)
         {
-            speed = _speed;
+            this.active = true;
         }
     }
 }

--- a/Assets/Scripts/Consequences/RotateConsequence.cs
+++ b/Assets/Scripts/Consequences/RotateConsequence.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace Consequences
 {
-    public class RotateConsequence : MonoBehaviour, IConsequence
+    public class RotateConsequence : AbstractConsequence
     {
 
         public float speed;
@@ -38,7 +38,7 @@ namespace Consequences
             }
         }
 
-        public void execute(TriggerData? data)
+        public override void execute(TriggerData? data)
         {
             this.active = true;
         }

--- a/Assets/Scripts/Consequences/SlideToDestinationConsequence.cs
+++ b/Assets/Scripts/Consequences/SlideToDestinationConsequence.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace Consequences
 {
-    public class SlideToDestinationConsequence : MonoBehaviour, IConsequence
+    public class SlideToDestinationConsequence : AbstractConsequence
     {
         public Transform destination;
         public float speed = 0.1f;
@@ -58,7 +58,7 @@ namespace Consequences
             }
         }
 
-        public void execute(TriggerData? data)
+        public override void execute(TriggerData? data)
         {
             this.start = true;
         }

--- a/Assets/Scripts/Consequences/SlideToDestinationConsequence.cs
+++ b/Assets/Scripts/Consequences/SlideToDestinationConsequence.cs
@@ -1,10 +1,63 @@
 #nullable enable
 using Triggers;
+using UnityEngine;
 
 namespace Consequences
 {
-    public class SlideToDestinationConsequence : SlideToDestination, IConsequence
+    public class SlideToDestinationConsequence : MonoBehaviour, IConsequence
     {
+        public Transform destination;
+        public float speed = 0.1f;
+        public bool start = false;
+        public bool forward = true;
+        public Transform objectToSlide = null;
+        protected Vector3 startPos;
+        public bool shouldReturn = true;
+
+        private void Start()
+        {
+            destination.parent = null;
+            startPos = transform.position;
+
+            if (objectToSlide == null)
+            {
+                objectToSlide = transform;
+            }
+        }
+
+        protected Transform getTransform()
+        {
+            if (this.objectToSlide)
+            {
+                return objectToSlide;
+            }
+            else
+            {
+                return this.transform;
+            }
+        }
+
+        void Update()
+        {
+            if (start)
+            {
+                Vector3 dest = forward ? destination.position : startPos;
+                if ((dest - getTransform().position).magnitude > speed)
+                {
+                    getTransform().position +=
+                        (dest - getTransform().position).normalized * speed * Time.deltaTime * 50;
+                }
+                else
+                {
+                    getTransform().position = dest;
+                    if (shouldReturn)
+                    {
+                        forward = !forward;
+                    }
+                }
+            }
+        }
+
         public void execute(TriggerData? data)
         {
             this.start = true;

--- a/Assets/Scripts/Consequences/ToggleAudioConsequence.cs
+++ b/Assets/Scripts/Consequences/ToggleAudioConsequence.cs
@@ -5,7 +5,7 @@ using Consequences;
 using Triggers;
 using UnityEngine;
 
-public class ToggleAudioConsequence : MonoBehaviour, IConsequence
+public class ToggleAudioConsequence : AbstractConsequence
 {
     public AudioSource sourceOfAudio;
 
@@ -18,7 +18,7 @@ public class ToggleAudioConsequence : MonoBehaviour, IConsequence
     }
 
 
-    public void execute(TriggerData? data)
+    public override void execute(TriggerData? data)
     {
         if (this.sourceOfAudio.isPlaying)
         {

--- a/Assets/Scripts/Consequences/ToggleLightColorConsequence.cs
+++ b/Assets/Scripts/Consequences/ToggleLightColorConsequence.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace Consequences
 {
-    public class ToggleLightColorConsequence : MonoBehaviour, IConsequence
+    public class ToggleLightColorConsequence : AbstractConsequence
     {
         public Color goingTo;
         public Light lightToToggle;
@@ -20,7 +20,7 @@ namespace Consequences
             
         }
 
-        public void execute(TriggerData? data)
+        public override void execute(TriggerData? data)
         {
             if (!lightToToggle) return;
 

--- a/Assets/Scripts/Consequences/ToggleTriggerConsequence.cs
+++ b/Assets/Scripts/Consequences/ToggleTriggerConsequence.cs
@@ -5,7 +5,7 @@ using Consequences;
 using Triggers;
 using UnityEngine;
 
-public class ToggleTriggerConsequence : MonoBehaviour, IConsequence
+public class ToggleTriggerConsequence : AbstractConsequence
 {
 
     public AbstractTrigger toToggle;
@@ -19,7 +19,7 @@ public class ToggleTriggerConsequence : MonoBehaviour, IConsequence
 
     }
 
-    public void execute(TriggerData? data)
+    public override void execute(TriggerData? data)
     {
         this.toToggle.enabled = !this.toToggle.enabled;
     }


### PR DESCRIPTION
Because interfaces are preferable to work with in code
But Unity3D's inspector does not see interfaces, only classes

Cause all objects that inherit from IConsequence to also inherit from AbstractConsequence, which right now does almost nothing - but it does let you use Consequences in the Inspector the way a Unity user would expect