### PR TITLE
#268 Reset player health state *before* the respawn delay

### DIFF
--- a/Assets/Scripts/Player/Death/PlayerRespawner.cs
+++ b/Assets/Scripts/Player/Death/PlayerRespawner.cs
@@ -61,6 +61,7 @@ namespace Player.Death
 
             if (deathCharacteristics.shouldRespawn())
             {
+                resetPlayerHealthState();
                 yield return new WaitForSeconds(deathSeconds);
                 player.Character.gameObject.GetComponent<KinematicCharacterMotor>().SetPosition(this.getRespawnLocation());
                 resetPlayerHealthState();


### PR DESCRIPTION
This avoids dying and then dying from DoT (e.g. bleeding) while busy dying #268